### PR TITLE
Update crispy_forms_bulma_field.py

### DIFF
--- a/django_crispy_bulma/templatetags/crispy_forms_bulma_field.py
+++ b/django_crispy_bulma/templatetags/crispy_forms_bulma_field.py
@@ -138,7 +138,7 @@ class CrispyBulmaFieldNode(template.Node):
                 else:
                     widget.attrs[attribute_name] = template.Variable(attribute).resolve(context)
 
-        return field
+        return str(field)
 
 
 @register.tag(name="crispy_field")


### PR DESCRIPTION
Fix for BoundField error when using Django 4.0 and latest v of Crispy Forms.